### PR TITLE
Fix #4 - Full support for includes with sparse fieldsets

### DIFF
--- a/pio/model/response.py
+++ b/pio/model/response.py
@@ -1,0 +1,135 @@
+"""
+APIResponse class for handling JSON:API responses with included resources.
+
+This module provides the APIResponse class that wraps API response data,
+merges included resources into relationship data, and maintains backward
+compatibility by inheriting from list.
+"""
+
+
+class APIResponse(list):
+    """
+    Wraps API response data and provides access to included resources.
+
+    This class merges included resources into relationship data while maintaining
+    backward compatibility by inheriting from list. All standard list operations
+    (iteration, indexing, len, isinstance checks) work as expected.
+
+    Attributes:
+        included: List of included resource objects from the API response.
+        meta: Metadata dictionary from the API response.
+
+    Example:
+        >>> response = await pio.campaigns.get(id=123, include=["opportunity"])
+        >>> # Access data like a list
+        >>> for campaign in response:
+        ...     print(campaign['attributes']['name'])
+        >>> # Access merged relationship data
+        >>> opp = response[0]['relationships']['opportunity']['data']
+        >>> print(opp['attributes']['name'])  # Full attributes available
+        >>> # Access raw included array
+        >>> print(response.included)
+    """
+
+    def __init__(self, data, included=None, meta=None):
+        """
+        Initialize API response.
+
+        Args:
+            data: List of resource objects from the API response.
+            included: List of included resource objects.
+            meta: Metadata from the API response.
+        """
+        self.included = included or []
+        self.meta = meta or {}
+
+        # Merge included resources into relationship data
+        merged_data = self._merge_included(data, self.included)
+
+        # Initialize list with merged data
+        if isinstance(merged_data, list):
+            super().__init__(merged_data)
+        else:
+            super().__init__([merged_data] if merged_data else [])
+
+    def _merge_included(self, data, included):
+        """
+        Merge included resources into their corresponding relationships.
+
+        For each relationship that has a 'data' field with type and id,
+        find the matching resource in the included array and merge its
+        full attributes and relationships into the relationship data.
+
+        Args:
+            data: List of primary resource objects.
+            included: List of included resource objects.
+
+        Returns:
+            Data with included resources merged into relationships.
+        """
+        if not included:
+            return data
+
+        # Create lookup dict for included resources: {(type, id): resource}
+        included_map = {
+            (resource.get("type"), resource.get("id")): resource
+            for resource in included
+        }
+
+        def merge_relationships(obj):
+            """Recursively merge included resources into an object's relationships."""
+            if not isinstance(obj, dict):
+                return obj
+
+            # Process relationships if they exist
+            relationships = obj.get("relationships", {})
+            for rel_name, rel_data in relationships.items():
+                if not isinstance(rel_data, dict):
+                    continue
+
+                rel_data_obj = rel_data.get("data")
+
+                if rel_data_obj is None:
+                    continue
+
+                # Handle to-one relationships (single object)
+                if isinstance(rel_data_obj, dict):
+                    key = (rel_data_obj.get("type"), rel_data_obj.get("id"))
+                    if key in included_map:
+                        # Merge the full included resource
+                        merged = {**included_map[key]}
+                        # Recursively merge nested relationships
+                        merge_relationships(merged)
+                        rel_data["data"] = merged
+
+                # Handle to-many relationships (array of objects)
+                elif isinstance(rel_data_obj, list):
+                    merged_list = []
+                    for item in rel_data_obj:
+                        if not isinstance(item, dict):
+                            merged_list.append(item)
+                            continue
+                        key = (item.get("type"), item.get("id"))
+                        if key in included_map:
+                            merged = {**included_map[key]}
+                            merge_relationships(merged)
+                            merged_list.append(merged)
+                        else:
+                            merged_list.append(item)
+                    rel_data["data"] = merged_list
+
+            return obj
+
+        # Process each item in data
+        if isinstance(data, list):
+            return [merge_relationships(item) for item in data]
+        else:
+            return merge_relationships(data)
+
+    def __repr__(self):
+        """String representation."""
+        return (
+            f"APIResponse({len(self)} items, "
+            f"included={len(self.included)} items, "
+            f"meta={list(self.meta.keys()) if self.meta else []})"
+        )

--- a/pio/pio.py
+++ b/pio/pio.py
@@ -9,6 +9,7 @@ import csv
 import time
 from typing import Unpack, Union
 from pio.client import PlacementsIOClient
+from pio.model.response import APIResponse
 from pio.error.api_error import APIError
 from pio.model.environment import API
 from pio.model.report import COLUMNS
@@ -85,7 +86,7 @@ class PlacementsIO:
             fields: list = None,
             params: dict = None,
             **args: Unpack[ModelFilterAccount],
-        ) -> list:
+        ) -> APIResponse:
             """
             Get existing resources within the service
             """

--- a/pio/pio.py
+++ b/pio/pio.py
@@ -83,7 +83,7 @@ class PlacementsIO:
         async def get(
             self,
             include: list = None,
-            fields: list = None,
+            fields: Union[list, dict] = None,
             params: dict = None,
             **args: Unpack[ModelFilterAccount],
         ) -> APIResponse:

--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,28 @@ Providing no parameters will return all of the data for that resource; however i
 
 The response from the SDK will be a list of dictionaries, regardless of the number of results that will be returned.
 
+#### Sparse Fieldsets
+
+The `fields` parameter limits which attributes are returned. It accepts two formats:
+
+**List format** - applies to the primary resource:
+```python
+# Returns only ad-server-id, name and start-date for line-items
+pio.line_items.get(fields=["ad-server-id", "name", "start-date"])
+```
+
+**Dict format** - specify fields per resource type (useful with `include`):
+```python
+# Get line items with campaigns, limiting fields on both
+line_items = await pio.line_items.get(
+    include=["campaigns"],
+    fields={
+        "line-items": ["ad-server-id", "name", "start-date"],
+        "campaigns": ["ad-server-id", "end-date"]
+    }
+)
+```
+
 ### Update
 
 Requests to the `update` method will provide a HTTP patch requests to the Placements.io resource for the resource ids that are specified.

--- a/test/data/get/campaigns_with_included.json
+++ b/test/data/get/campaigns_with_included.json
@@ -1,0 +1,97 @@
+{
+  "data": [
+    {
+      "id": "41",
+      "type": "campaigns",
+      "links": {
+        "self": "https://api.placements.io/v1/campaigns/41"
+      },
+      "attributes": {
+        "name": "Test Campaign 1",
+        "trafficker-info": {
+          "email": "trafficker@example.org"
+        }
+      },
+      "relationships": {
+        "advertiser": {
+          "links": {
+            "self": "https://api.placements.io/v1/campaigns/41/relationships/advertiser",
+            "related": "https://api.placements.io/v1/campaigns/41/advertiser"
+          },
+          "data": {
+            "type": "accounts",
+            "id": "3549"
+          }
+        },
+        "opportunity": {
+          "links": {
+            "self": "https://api.placements.io/v1/campaigns/41/relationships/opportunity",
+            "related": "https://api.placements.io/v1/campaigns/41/opportunity"
+          },
+          "data": {
+            "type": "opportunities",
+            "id": "485396"
+          }
+        },
+        "line-items": {
+          "links": {
+            "self": "https://api.placements.io/v1/campaigns/41/relationships/line-items",
+            "related": "https://api.placements.io/v1/campaigns/41/line-items"
+          },
+          "data": [
+            { "type": "line_items", "id": "101" },
+            { "type": "line_items", "id": "102" }
+          ]
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "3549",
+      "type": "accounts",
+      "attributes": {
+        "name": "Test Advertiser Inc.",
+        "account-type": "advertiser",
+        "external-id": "ADV-001"
+      },
+      "relationships": {}
+    },
+    {
+      "id": "485396",
+      "type": "opportunities",
+      "attributes": {
+        "name": "LaGuardia Inc. - New Product",
+        "stage-name": "Closed Won",
+        "budget": "50000.00"
+      },
+      "relationships": {
+        "account": {
+          "data": { "type": "accounts", "id": "3549" }
+        }
+      }
+    },
+    {
+      "id": "101",
+      "type": "line_items",
+      "attributes": {
+        "name": "Display Banner - Homepage",
+        "rate": "15.00"
+      },
+      "relationships": {}
+    },
+    {
+      "id": "102",
+      "type": "line_items",
+      "attributes": {
+        "name": "Display Banner - Sidebar",
+        "rate": "10.00"
+      },
+      "relationships": {}
+    }
+  ],
+  "meta": {
+    "record-count": 1,
+    "page-count": 1
+  }
+}

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,0 +1,51 @@
+"""
+Tests for PlacementsIOClient helper methods
+"""
+
+from pio.client import PlacementsIOClient
+
+
+# ============================================================================
+# Tests for _fields_values sparse fieldsets
+# ============================================================================
+
+
+def test_fields_values_with_list():
+    """Test _fields_values with list format (backwards compatible)"""
+    client = PlacementsIOClient()
+    result = client._fields_values("campaigns", ["name", "id"])
+    assert result == {"fields[campaigns]": "name,id"}
+
+
+def test_fields_values_with_dict():
+    """Test _fields_values with dict format for multiple entity types"""
+    client = PlacementsIOClient()
+    result = client._fields_values("campaigns", {
+        "campaigns": ["name", "ad-server-info"],
+        "accounts": ["custom-fields"]
+    })
+    assert result == {
+        "fields[campaigns]": "name,ad-server-info",
+        "fields[accounts]": "custom-fields"
+    }
+
+
+def test_fields_values_normalizes_underscores():
+    """Test _fields_values normalizes underscores to hyphens"""
+    client = PlacementsIOClient()
+    result = client._fields_values("line_items", {
+        "line_items": ["name"],
+        "accounts": ["id"]
+    })
+    assert result == {
+        "fields[line-items]": "name",
+        "fields[accounts]": "id"
+    }
+
+
+def test_fields_values_empty():
+    """Test _fields_values returns empty dict for empty/None inputs"""
+    client = PlacementsIOClient()
+    assert client._fields_values("campaigns", None) == {}
+    assert client._fields_values("campaigns", []) == {}
+    assert client._fields_values("campaigns", {}) == {}

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -49,3 +49,106 @@ def test_fields_values_empty():
     assert client._fields_values("campaigns", None) == {}
     assert client._fields_values("campaigns", []) == {}
     assert client._fields_values("campaigns", {}) == {}
+
+
+# ============================================================================
+# Tests for _merge_includes_into_fields
+# ============================================================================
+
+
+def test_merge_includes_into_fields_list():
+    """Test merging includes into fields when fields is a list."""
+    client = PlacementsIOClient()
+
+    result = client._merge_includes_into_fields(
+        service="campaigns",
+        includes=["advertiser", "line-items"],
+        fields=["name"]
+    )
+
+    assert "name" in result
+    assert "advertiser" in result
+    assert "line-items" in result
+
+
+def test_merge_includes_into_fields_list_no_duplicates():
+    """Test that includes already in fields aren't duplicated."""
+    client = PlacementsIOClient()
+
+    result = client._merge_includes_into_fields(
+        service="campaigns",
+        includes=["advertiser"],
+        fields=["name", "advertiser"]  # advertiser already present
+    )
+
+    assert result.count("advertiser") == 1
+
+
+def test_merge_includes_into_fields_dict():
+    """Test merging includes into fields when fields is a dict."""
+    client = PlacementsIOClient()
+
+    result = client._merge_includes_into_fields(
+        service="campaigns",
+        includes=["advertiser"],
+        fields={"campaigns": ["name"], "accounts": ["custom-fields"]}
+    )
+
+    # Should add to primary service
+    assert "advertiser" in result["campaigns"]
+    # Should NOT add to other resource types
+    assert "advertiser" not in result["accounts"]
+
+
+def test_merge_includes_into_fields_none_includes():
+    """Test that None includes returns fields unchanged."""
+    client = PlacementsIOClient()
+
+    result = client._merge_includes_into_fields(
+        service="campaigns",
+        includes=None,
+        fields=["name"]
+    )
+
+    assert result == ["name"]
+
+
+def test_merge_includes_into_fields_none_fields():
+    """Test that None fields returns None (no sparse fieldsets)."""
+    client = PlacementsIOClient()
+
+    result = client._merge_includes_into_fields(
+        service="campaigns",
+        includes=["advertiser"],
+        fields=None
+    )
+
+    assert result is None
+
+
+def test_merge_includes_into_fields_underscore_service():
+    """Test handling of underscored service names like line_items."""
+    client = PlacementsIOClient()
+
+    result = client._merge_includes_into_fields(
+        service="line_items",
+        includes=["campaign"],
+        fields={"line-items": ["name"]}
+    )
+
+    assert "campaign" in result["line-items"]
+
+
+def test_merge_includes_into_fields_dict_primary_not_specified():
+    """Test that when dict fields doesn't include primary service, nothing is added."""
+    client = PlacementsIOClient()
+
+    result = client._merge_includes_into_fields(
+        service="campaigns",
+        includes=["advertiser"],
+        fields={"accounts": ["custom-fields"]}  # no campaigns key
+    )
+
+    # Should return unchanged
+    assert result == {"accounts": ["custom-fields"]}
+    assert "campaigns" not in result

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -368,5 +368,6 @@ async def test_fields_with_include_sends_both_params(mock_get_capture_request):
     request = mock_get_capture_request[0]
     params = dict(request.url.params)
     assert params["include"] == "advertiser"
-    assert params["fields[campaigns]"] == "name"
+    # Include is merged into primary resource's fields to ensure relationship data is returned
+    assert params["fields[campaigns]"] == "name,advertiser"
     assert params["fields[accounts]"] == "custom-fields"

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -9,6 +9,7 @@ import httpx
 from pytest_httpx import HTTPXMock
 from pio import PlacementsIO
 from pio.model.service import services
+from pio.model.response import APIResponse
 from pio.error.api_error import APIError
 
 API_SERVICES = [_ for _ in services if _ != "reports"]
@@ -98,3 +99,194 @@ async def test_get_rate_limit(mock_rate_limit):
     api_response = await pio.accounts.get()
     print("API Response", api_response)
     assert isinstance(api_response, list)
+
+
+# ============================================================================
+# Tests for APIResponse and included resources
+# ============================================================================
+
+
+@pytest.fixture()
+def mock_get_with_included(httpx_mock: HTTPXMock):
+    """
+    Mocks a GET request that returns included resources
+    """
+    with open("test/data/get/campaigns_with_included.json", encoding="utf-8") as response:
+        httpx_mock.add_response(
+            method="GET",
+            url=re.compile(URL_REGEX),
+            json=json.load(response),
+            status_code=200,
+        )
+
+
+@pytest.mark.asyncio
+async def test_api_response_is_list_compatible(mock_get_success):
+    """Test that APIResponse is compatible with list operations"""
+    pio = PlacementsIO(environment="staging", token="foo")
+    api_response = await pio.campaigns.get()
+
+    # Should be an instance of list (backward compatibility)
+    assert isinstance(api_response, list)
+    assert isinstance(api_response, APIResponse)
+
+    # Should support len()
+    assert len(api_response) >= 0
+
+    # Should support iteration
+    for item in api_response:
+        assert isinstance(item, dict)
+
+    # Should support indexing (if there are items)
+    if len(api_response) > 0:
+        assert isinstance(api_response[0], dict)
+
+
+@pytest.mark.asyncio
+async def test_api_response_has_included_property(mock_get_success):
+    """Test that APIResponse has accessible included property"""
+    pio = PlacementsIO(environment="staging", token="foo")
+    api_response = await pio.campaigns.get()
+
+    # Should have included property (empty list when no included in response)
+    assert hasattr(api_response, "included")
+    assert isinstance(api_response.included, list)
+
+
+@pytest.mark.asyncio
+async def test_api_response_has_meta_property(mock_get_success):
+    """Test that APIResponse has accessible meta property"""
+    pio = PlacementsIO(environment="staging", token="foo")
+    api_response = await pio.campaigns.get()
+
+    # Should have meta property (empty dict when no meta in response)
+    assert hasattr(api_response, "meta")
+    assert isinstance(api_response.meta, dict)
+
+
+@pytest.mark.asyncio
+async def test_included_resources_merged_to_one(mock_get_with_included):
+    """Test that included resources are merged into to-one relationships"""
+    pio = PlacementsIO(environment="staging", token="foo")
+    api_response = await pio.campaigns.get()
+
+    assert len(api_response) == 1
+    campaign = api_response[0]
+
+    # Check advertiser relationship was merged
+    advertiser_data = campaign["relationships"]["advertiser"]["data"]
+    assert advertiser_data["id"] == "3549"
+    assert advertiser_data["type"] == "accounts"
+    assert "attributes" in advertiser_data
+    assert advertiser_data["attributes"]["name"] == "Test Advertiser Inc."
+    assert advertiser_data["attributes"]["account-type"] == "advertiser"
+
+    # Check opportunity relationship was merged
+    opportunity_data = campaign["relationships"]["opportunity"]["data"]
+    assert opportunity_data["id"] == "485396"
+    assert opportunity_data["type"] == "opportunities"
+    assert "attributes" in opportunity_data
+    assert opportunity_data["attributes"]["name"] == "LaGuardia Inc. - New Product"
+    assert opportunity_data["attributes"]["stage-name"] == "Closed Won"
+
+
+@pytest.mark.asyncio
+async def test_included_resources_merged_to_many(mock_get_with_included):
+    """Test that included resources are merged into to-many relationships"""
+    pio = PlacementsIO(environment="staging", token="foo")
+    api_response = await pio.campaigns.get()
+
+    campaign = api_response[0]
+
+    # Check line-items relationship was merged (to-many)
+    line_items_data = campaign["relationships"]["line-items"]["data"]
+    assert len(line_items_data) == 2
+
+    # First line item
+    assert line_items_data[0]["id"] == "101"
+    assert line_items_data[0]["type"] == "line_items"
+    assert "attributes" in line_items_data[0]
+    assert line_items_data[0]["attributes"]["name"] == "Display Banner - Homepage"
+
+    # Second line item
+    assert line_items_data[1]["id"] == "102"
+    assert line_items_data[1]["type"] == "line_items"
+    assert "attributes" in line_items_data[1]
+    assert line_items_data[1]["attributes"]["name"] == "Display Banner - Sidebar"
+
+
+@pytest.mark.asyncio
+async def test_nested_relationships_merged(mock_get_with_included):
+    """Test that nested relationships in included resources are also merged"""
+    pio = PlacementsIO(environment="staging", token="foo")
+    api_response = await pio.campaigns.get()
+
+    campaign = api_response[0]
+
+    # The opportunity has a nested relationship to account
+    opportunity_data = campaign["relationships"]["opportunity"]["data"]
+
+    # Check that the nested account relationship was also merged
+    nested_account = opportunity_data["relationships"]["account"]["data"]
+    assert nested_account["id"] == "3549"
+    assert nested_account["type"] == "accounts"
+    assert "attributes" in nested_account
+    assert nested_account["attributes"]["name"] == "Test Advertiser Inc."
+
+
+@pytest.mark.asyncio
+async def test_included_property_accessible(mock_get_with_included):
+    """Test that raw included array is accessible via property"""
+    pio = PlacementsIO(environment="staging", token="foo")
+    api_response = await pio.campaigns.get()
+
+    # Should have 4 included resources
+    assert len(api_response.included) == 4
+
+    # Verify included types
+    included_types = {item["type"] for item in api_response.included}
+    assert "accounts" in included_types
+    assert "opportunities" in included_types
+    assert "line_items" in included_types
+
+
+@pytest.mark.asyncio
+async def test_meta_property_accessible(mock_get_with_included):
+    """Test that meta is accessible via property"""
+    pio = PlacementsIO(environment="staging", token="foo")
+    api_response = await pio.campaigns.get()
+
+    assert api_response.meta["record-count"] == 1
+    assert api_response.meta["page-count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_included_does_not_break(mock_get_success):
+    """Test that responses without included array work correctly"""
+    pio = PlacementsIO(environment="staging", token="foo")
+    api_response = await pio.campaigns.get()
+
+    # Should work without included
+    assert isinstance(api_response, list)
+    assert api_response.included == []
+
+    # Relationships should be preserved but not merged
+    if len(api_response) > 0:
+        campaign = api_response[0]
+        if "relationships" in campaign and "advertiser" in campaign["relationships"]:
+            advertiser_data = campaign["relationships"]["advertiser"]["data"]
+            # Should only have type and id (not merged attributes)
+            assert "type" in advertiser_data
+            assert "id" in advertiser_data
+
+
+@pytest.mark.asyncio
+async def test_api_response_repr(mock_get_with_included):
+    """Test APIResponse string representation"""
+    pio = PlacementsIO(environment="staging", token="foo")
+    api_response = await pio.campaigns.get()
+
+    repr_str = repr(api_response)
+    assert "APIResponse" in repr_str
+    assert "1 items" in repr_str
+    assert "included=4 items" in repr_str


### PR DESCRIPTION
Fixes issue #4 

- Introduce `APIResponse` class for GET requests:
  - Extends `list` for backwards compatibility
  - Exposes `meta` and `included` fields from the response for use
  - Hydrates relationship data on resources using data from the `included` array
- Enhancements to sparse fieldset functionality:
  - Support `dict` fieldsets that specify fields by resource type
  - When using an `include` and a sparse fieldset on the requested resource, ensure the included relationship is present in the sparse fieldset.
- Documentation updates
  - Document behavior of includes with sparse fieldsets
  - Document behavior and limitations of nested includes